### PR TITLE
Shrink Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22.3
+FROM golang:1.22.3-alpine AS builder
 
 WORKDIR /app
 
 COPY . .
 
-RUN go mod download
-
 # Build
-RUN go build
+RUN go build -o back-bot
 
-CMD ["./back-bot", "-f", "super-secret-token.txt"]
+FROM alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/back_repo ./back_repo
+COPY --from=builder /app/back-bot .
+
+CMD ["/bin/sh", "-c", "./back-bot -t $TOKEN"]

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	err := bot.Open()
 	if err != nil {
 		fmt.Println("Error opening Discord session: ", err)
+		os.Exit(1)
 	}
 
 	// Wait here until CTRL-C or other term signal is received.


### PR DESCRIPTION
* Use a builder step to avoid including Go toolchain in executable image
* Use Alpine images (don't know how much of a difference it makes though)
* Prune unnecessary `go mod download` (`go build` does this when it needs to, and eliminating it eliminates an image layer)
* Read secret from env when container executes rather than building into image

These changes bring the resulting Docker image from 937MB to 19.4MB.

Also, I added a line to kill the process if there's an error connecting to Discord, which was a branch I triggered plenty of times while setting up my debug instance 🤦 